### PR TITLE
Added endianess check

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -31,5 +31,12 @@ AC_CHECK_TYPE(CRYPTO_RWLOCK,[],
               [#include <openssl/crypto.h>])
 AC_CHECK_FUNCS([RSA_PKCS1_OpenSSL RSA_meth_new DH_meth_new])
 
+AC_C_BIGENDIAN(
+  AC_DEFINE(B_ENDIAN, 1, [machine is big-endian]),
+  AC_DEFINE(L_ENDIAN, 1, [machine is little-endian]),
+  AC_MSG_ERROR(unknown endianess),
+  AC_MSG_ERROR(universial endianess not supported)
+)
+
 AC_CONFIG_FILES([Makefile])
 AC_OUTPUT

--- a/e_chil.c
+++ b/e_chil.c
@@ -76,6 +76,8 @@
 #endif
 #include <openssl/bn.h>
 
+#include "config.h"
+
 /*-
  * Attribution notice: nCipher have said several times that it's OK for
  * us to implement a general interface to their boxes, and recently declared


### PR DESCRIPTION
When converting to and from MPI to BN, we need to have L_ENDIAN defined on little-endian machines.
So added AC_C_BIGENDIAN to configure.ac

Also, autoconf is creating a config.h which we weren't using.
