### PR TITLE
Make sure we actually link against libltdl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@
 /ltmain.sh
 /m4/
 /missing
+/libltdl
 
 # Ignore all things produced by configure
 /.deps/

--- a/Makefile.am
+++ b/Makefile.am
@@ -15,4 +15,5 @@ chil_la_DEPENDENCIES = $(LTDLDEPS)
 chil_la_SOURCES = e_chil.c vendor_defns/hwcryptohook.h e_chil_err.h
 noinst_HEADERS = e_chil_err.c
 
+# Override the usual and make sure to install in OpenSSL's default engine store
 pkglibdir = $(libdir)/engines

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,10 +1,12 @@
+SUBDIRS=libltdl
+
 AUTOMAKE_OPTIONS = foreign
 ACLOCAL_AMFLAGS = -I m4
 
 pkglib_LTLIBRARIES = chil.la
 
 chil_la_LDFLAGS = -module -avoid-version
-chil_la_LDLADD = $(LIBLTDL)
+chil_la_LIBADD = $(LIBLTDL)
 chil_la_CPPFLAGS = $(LTDLINCL)
 chil_la_DEPENDENCIES = $(LTDLDEPS)
 
@@ -13,5 +15,4 @@ chil_la_DEPENDENCIES = $(LTDLDEPS)
 chil_la_SOURCES = e_chil.c vendor_defns/hwcryptohook.h e_chil_err.h
 noinst_HEADERS = e_chil_err.c
 
-# Override the usual and make sure to install in OpenSSL's default engine store
 pkglibdir = $(libdir)/engines

--- a/configure.ac
+++ b/configure.ac
@@ -6,6 +6,7 @@ AC_CONFIG_MACRO_DIR([m4])
 dnl m4_include([m4/ax_check_openssl.m4])
 
 AM_INIT_AUTOMAKE
+LT_CONFIG_LTDL_DIR([libltdl])
 LT_INIT([disable-static pic-only])
 LTDL_INIT
 


### PR DESCRIPTION
Hi Richard, the build didn't link against libltdl on my Ubuntu system, causing unresolved symbols.  This patch should make that more robust.  Usually when working with autotools I just paw at the problem until things work, but this seems to align pretty well with the Libtool/libltdl manual at https://www.gnu.org/software/libtool/manual/html_node/Distributing-libltdl.html#Distributing-libltdl (subproject variant). 

Also I set up the Makefile.am to pull the engines directory from the installed copy of OpenSSL.  Is this how one should do this?